### PR TITLE
Now quotes are added if they do NOT exist not as before if they alrea…

### DIFF
--- a/Source/Fs.Processes/Process.cs
+++ b/Source/Fs.Processes/Process.cs
@@ -908,9 +908,9 @@ namespace Fs.Processes
             executableFileName = executableFileName.Trim();
             var isQuoted = (executableFileName.StartsWith("\"", StringComparison.Ordinal) && executableFileName.EndsWith("\"", StringComparison.Ordinal));
 
-            if (isQuoted) commandLine.Append('"');
+            if (!isQuoted) commandLine.Append('"');
             commandLine.Append(executableFileName);
-            if (isQuoted) commandLine.Append('"');
+            if (!isQuoted) commandLine.Append('"');
 
             if (argumentsList != null)
             {


### PR DESCRIPTION
Hi, your code had an issue if spaces are in the executablename path like this:
```
var processInfo = new CreateProcessInfo
            {
                FileName = "c:\some space between\ping.exe",
                ArgumentsList = {"8.8.8.8"}
            };
```
The quote check was inverted.

It only worked because Windows seems to be tolerant and starts searching for other matching path parts. In this case it would try to start "c:\some", then "c:\some.exe" after that continue with "c:\some space.exe" and so one. If any of this files/directories exists it will either be started (which is very bad) or it will fail if for example "c:\some" is a directory or a text-file. Thats of course also bad but would not harm the system.

can you please merge this and publish a new nuget?