### PR TITLE
Added Job Object naming & opening

### DIFF
--- a/Source/Fs.Processes/Interop/Interop.Kernel32.cs
+++ b/Source/Fs.Processes/Interop/Interop.Kernel32.cs
@@ -209,6 +209,10 @@ internal partial class Interop
         [DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true, BestFitMapping = false, EntryPoint = "CreateJobObjectW")]
         internal static extern SafeJobObjectHandle CreateJobObject ( ref SECURITY_ATTRIBUTES lpJobAttributes, string lpName );
 
+        [DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true, BestFitMapping = false, EntryPoint = "OpenJobObjectW")]
+        internal static extern SafeJobObjectHandle OpenJobObject(uint dwDesiredAccess, BOOL bInheritHandle, string lpName);
+
+
         [DllImport("kernel32.dll", SetLastError = true, EntryPoint = "PostQueuedCompletionStatus")]
         internal static extern bool PostQueuedCompletionStatus (
             SafeIoCompletionPortHandle CompletionPort,


### PR DESCRIPTION
Currently, Fs.Processes doesn't support opening Job Objects or naming them at creation. This PR adds the necessary Interop, constructors & static method for such a thing.

This is a quick sketch of it, if another use of constructors and/or static methods fits the project better, I'd remodel the PR.